### PR TITLE
feat: add pana CI checks and rename Ease to EaseScope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+      - name: Install Melos
+        run: dart pub global activate melos
+      - name: Bootstrap
+        run: melos bootstrap
+      - name: Analyze
+        run: melos run analyze
+      - name: Format check
+        run: melos run format:check
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+      - name: Install Melos
+        run: dart pub global activate melos
+      - name: Bootstrap
+        run: melos bootstrap
+      - name: Run tests
+        run: melos run test:all
+
+  pana:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+      - name: Install Melos
+        run: dart pub global activate melos
+      - name: Bootstrap
+        run: melos bootstrap
+      - name: Install pana
+        run: dart pub global activate pana
+      - name: Run pana on ease_annotation
+        run: cd packages/ease_annotation && pana --no-warning
+      - name: Run pana on ease_generator
+        run: cd packages/ease_generator && pana --no-warning
+      - name: Run pana on ease_state_helper
+        run: cd packages/ease_state_helper && pana --no-warning

--- a/apps/example/lib/ease.g.dart
+++ b/apps/example/lib/ease.g.dart
@@ -25,7 +25,7 @@ import 'view_models/todo_view_model.dart';
 /// import 'ease.g.dart';
 ///
 /// void main() => runApp(
-///   Ease(providers: $easeProviders, child: MyApp()),
+///   EaseScope(providers: $easeProviders, child: MyApp()),
 /// );
 /// ```
 final $easeProviders = <ProviderBuilder>[

--- a/apps/example/lib/main.dart
+++ b/apps/example/lib/main.dart
@@ -8,12 +8,12 @@ import 'router/app_router.dart';
 import 'view_models/auth_view_model.dart';
 
 void main() {
-  initializeEase(); // Initialize DevTools (debug mode only)
+  initializeEaseDevTool(); // Initialize DevTools (debug mode only)
   StateNotifier.middleware = [
     LoggingMiddleware(),
     // Add your custom middleware
   ];
-  runApp(Ease(providers: $easeProviders, child: const MyApp()));
+  runApp(EaseScope(providers: $easeProviders, child: const MyApp()));
 }
 
 class MyApp extends StatefulWidget {

--- a/apps/example/lib/view_models/auth_view_model.dart
+++ b/apps/example/lib/view_models/auth_view_model.dart
@@ -41,7 +41,7 @@ class AuthStatus {
 }
 
 /// Auth ViewModel - demonstrates navigation guards with persistence
-@ease()
+@ease
 class AuthViewModel extends StateNotifier<AuthStatus> {
   AuthViewModel() : super(const AuthStatus());
 

--- a/apps/example/lib/view_models/cart_view_model.dart
+++ b/apps/example/lib/view_models/cart_view_model.dart
@@ -38,7 +38,7 @@ class CartStatus {
 }
 
 /// Cart ViewModel - demonstrates shopping cart with computed values
-@ease()
+@ease
 class CartViewModel extends StateNotifier<CartStatus> {
   CartViewModel() : super(const CartStatus());
 

--- a/apps/example/lib/view_models/counter_view_model.dart
+++ b/apps/example/lib/view_models/counter_view_model.dart
@@ -5,7 +5,7 @@ import 'package:flutter/widgets.dart';
 part 'counter_view_model.ease.dart';
 
 /// Counter ViewModel - demonstrates basic usage
-@ease()
+@ease
 class CounterViewModel extends StateNotifier<int> {
   CounterViewModel() : super(0);
 

--- a/apps/example/lib/view_models/form_view_model.dart
+++ b/apps/example/lib/view_models/form_view_model.dart
@@ -7,7 +7,7 @@ import '../models/form_field.dart';
 part 'form_view_model.ease.dart';
 
 /// Registration form ViewModel - demonstrates complex form handling
-@ease()
+@ease
 class RegistrationFormViewModel extends StateNotifier<RegistrationForm> {
   RegistrationFormViewModel() : super(const RegistrationForm());
 

--- a/apps/example/lib/view_models/local_form_view_model.dart
+++ b/apps/example/lib/view_models/local_form_view_model.dart
@@ -18,7 +18,7 @@ part 'local_form_view_model.ease.dart';
 ///   child: MyFormWidget(),
 /// )
 /// ```
-@ease(local: true)
+@Ease(local: true)
 class LocalFormViewModel extends StateNotifier<LocalFormState> {
   LocalFormViewModel() : super(const LocalFormState());
 

--- a/apps/example/lib/view_models/network_view_model.dart
+++ b/apps/example/lib/view_models/network_view_model.dart
@@ -60,7 +60,7 @@ class NetworkStatus {
 }
 
 /// Network ViewModel - demonstrates real API calls with caching
-@ease()
+@ease
 class NetworkViewModel extends StateNotifier<NetworkStatus> {
   NetworkViewModel() : super(const NetworkStatus());
 

--- a/apps/example/lib/view_models/pagination_view_model.dart
+++ b/apps/example/lib/view_models/pagination_view_model.dart
@@ -50,7 +50,7 @@ class PaginationStatus {
 }
 
 /// Pagination ViewModel - demonstrates infinite scroll with load more
-@ease()
+@ease
 class PaginationViewModel extends StateNotifier<PaginationStatus> {
   PaginationViewModel() : super(const PaginationStatus());
 

--- a/apps/example/lib/view_models/search_view_model.dart
+++ b/apps/example/lib/view_models/search_view_model.dart
@@ -45,7 +45,7 @@ class SearchStatus {
 }
 
 /// Search ViewModel - demonstrates debounced search with async operations
-@ease()
+@ease
 class SearchViewModel extends StateNotifier<SearchStatus> {
   SearchViewModel() : super(const SearchStatus());
 

--- a/apps/example/lib/view_models/theme_view_model.dart
+++ b/apps/example/lib/view_models/theme_view_model.dart
@@ -7,7 +7,7 @@ import '../models/theme.dart';
 part 'theme_view_model.ease.dart';
 
 /// Theme ViewModel - demonstrates app-wide state management
-@ease()
+@ease
 class ThemeViewModel extends StateNotifier<AppTheme> {
   ThemeViewModel() : super(const AppTheme());
 

--- a/apps/example/lib/view_models/todo_view_model.dart
+++ b/apps/example/lib/view_models/todo_view_model.dart
@@ -7,7 +7,7 @@ import '../models/todo.dart';
 part 'todo_view_model.ease.dart';
 
 /// Todo ViewModel - demonstrates list management
-@ease()
+@ease
 class TodoViewModel extends StateNotifier<List<Todo>> {
   TodoViewModel() : super([]);
 

--- a/apps/example/test/widget_test.dart
+++ b/apps/example/test/widget_test.dart
@@ -183,7 +183,7 @@ void main() {
     testWidgets('provides all states', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Ease(
+          home: EaseScope(
             providers: $easeProviders,
             child: Builder(
               builder: (context) {
@@ -212,7 +212,7 @@ void main() {
     testWidgets('generic get<T>() works', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Ease(
+          home: EaseScope(
             providers: $easeProviders,
             child: Builder(
               builder: (context) {
@@ -232,7 +232,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          home: Ease(
+          home: EaseScope(
             providers: $easeProviders,
             child: Builder(
               builder: (context) {

--- a/apps/shopping_app/lib/ease.g.dart
+++ b/apps/shopping_app/lib/ease.g.dart
@@ -21,7 +21,7 @@ import 'features/products/view_models/products_view_model.dart';
 /// import 'ease.g.dart';
 ///
 /// void main() => runApp(
-///   Ease(providers: $easeProviders, child: MyApp()),
+///   EaseScope(providers: $easeProviders, child: MyApp()),
 /// );
 /// ```
 final $easeProviders = <ProviderBuilder>[

--- a/apps/shopping_app/lib/features/auth/view_models/auth_view_model.dart
+++ b/apps/shopping_app/lib/features/auth/view_models/auth_view_model.dart
@@ -12,7 +12,7 @@ import '../models/user.dart';
 
 part 'auth_view_model.ease.dart';
 
-@ease()
+@ease
 class AuthViewModel extends StateNotifier<AuthState> {
   final ApiService _apiService;
 

--- a/apps/shopping_app/lib/features/cart/view_models/cart_view_model.dart
+++ b/apps/shopping_app/lib/features/cart/view_models/cart_view_model.dart
@@ -9,7 +9,7 @@ import '../models/cart_state.dart';
 
 part 'cart_view_model.ease.dart';
 
-@ease()
+@ease
 class CartViewModel extends StateNotifier<CartState> {
   CartViewModel() : super(const CartState());
 

--- a/apps/shopping_app/lib/features/checkout/view_models/checkout_view_model.dart
+++ b/apps/shopping_app/lib/features/checkout/view_models/checkout_view_model.dart
@@ -8,7 +8,7 @@ import '../models/checkout_state.dart';
 
 part 'checkout_view_model.ease.dart';
 
-@ease()
+@ease
 class CheckoutViewModel extends StateNotifier<CheckoutState> {
   CheckoutViewModel() : super(const CheckoutState());
 

--- a/apps/shopping_app/lib/features/orders/view_models/orders_view_model.dart
+++ b/apps/shopping_app/lib/features/orders/view_models/orders_view_model.dart
@@ -8,7 +8,7 @@ import '../models/orders_state.dart';
 
 part 'orders_view_model.ease.dart';
 
-@ease()
+@ease
 class OrdersViewModel extends StateNotifier<OrdersState> {
   OrdersViewModel() : super(const OrdersState());
 

--- a/apps/shopping_app/lib/features/products/view_models/products_view_model.dart
+++ b/apps/shopping_app/lib/features/products/view_models/products_view_model.dart
@@ -8,7 +8,7 @@ import '../models/products_state.dart';
 
 part 'products_view_model.ease.dart';
 
-@ease()
+@ease
 class ProductsViewModel extends StateNotifier<ProductsState> {
   final ApiService _apiService;
 

--- a/apps/shopping_app/lib/main.dart
+++ b/apps/shopping_app/lib/main.dart
@@ -13,13 +13,13 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   // Initialize Ease DevTools (debug mode only)
-  initializeEase();
+  initializeEaseDevTool();
 
   // Initialize storage before app starts
   final prefs = await SharedPreferences.getInstance();
   StorageService.initialize(prefs);
 
-  runApp(Ease(providers: $easeProviders, child: const ShoppingApp()));
+  runApp(EaseScope(providers: $easeProviders, child: const ShoppingApp()));
 }
 
 class ShoppingApp extends StatefulWidget {

--- a/apps/shopping_app/test/widget_test.dart
+++ b/apps/shopping_app/test/widget_test.dart
@@ -8,7 +8,7 @@ import 'package:shopping_app/main.dart';
 void main() {
   testWidgets('Shopping app loads', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Ease(providers: $easeProviders, child: const ShoppingApp()),
+      EaseScope(providers: $easeProviders, child: const ShoppingApp()),
     );
     await tester.pump();
 

--- a/extensions/ease-state-helper/README.md
+++ b/extensions/ease-state-helper/README.md
@@ -46,7 +46,7 @@ import 'counter_view_model.dart';
 
 void main() {
   runApp(
-    Ease(
+    EaseScope(
       providers: [
         (child) => CounterViewModelProvider(child: child),
         // ... other providers

--- a/extensions/ease-state-helper/src/templates/easeFile.ts
+++ b/extensions/ease-state-helper/src/templates/easeFile.ts
@@ -85,7 +85,7 @@ extension ${className}Context on BuildContext {
       throw StateError(
         'No ${className} found in widget tree.\\n'
         'Make sure you:\\n'
-        '1. Wrapped your app with Ease widget: Ease(providers: [...], child: MyApp())\\n'
+        '1. Wrapped your app with EaseScope widget: EaseScope(providers: [...], child: MyApp())\\n'
         '2. Added ${className}Provider to your providers list',
       );
     }
@@ -98,7 +98,7 @@ extension ${className}Context on BuildContext {
       throw StateError(
         'No ${className} found in widget tree.\\n'
         'Make sure you:\\n'
-        '1. Wrapped your app with Ease widget: Ease(providers: [...], child: MyApp())\\n'
+        '1. Wrapped your app with EaseScope widget: EaseScope(providers: [...], child: MyApp())\\n'
         '2. Added ${className}Provider to your providers list',
       );
     }
@@ -114,7 +114,7 @@ extension ${className}Context on BuildContext {
       throw StateError(
         'No ${className} found in widget tree.\\n'
         'Make sure you:\\n'
-        '1. Wrapped your app with Ease widget: Ease(providers: [...], child: MyApp())\\n'
+        '1. Wrapped your app with EaseScope widget: EaseScope(providers: [...], child: MyApp())\\n'
         '2. Added ${className}Provider to your providers list',
       );
     }

--- a/melos.yaml
+++ b/melos.yaml
@@ -12,11 +12,6 @@ command:
   version:
     linkToCommits: true
     workspaceChangelog: true
-    # Tag format: package_name-vX.Y.Z (matches pub.dev pattern)
-    tagPrefix: ""
-  publish:
-    hooks:
-      pre: melos run analyze
 
 scripts:
   # Dependencies
@@ -136,6 +131,15 @@ scripts:
       flutter: true
       noPrivate: true
 
+
+  # Package scoring
+  pana:
+    description: Run pana scoring analysis
+    run: pana --no-warning
+    exec:
+      concurrency: 1
+    packageFilters:
+      noPrivate: true
 
   # Maintenance
   clean:

--- a/packages/ease_annotation/lib/src/annotation.dart
+++ b/packages/ease_annotation/lib/src/annotation.dart
@@ -50,10 +50,16 @@
 /// // Access within the subtree
 /// final form = context.formState;
 /// ```
-class ease {
+class Ease {
   /// If true, the provider will NOT be registered in the global Ease widget.
   /// Use for scoped state that should be manually placed in the widget tree.
   final bool local;
 
-  const ease({this.local = false});
+  const Ease({this.local = false});
 }
+
+/// Annotation for marking StateNotifier classes for code generation.
+///
+/// Use `@ease` for global providers (default behavior).
+/// Use `@Ease(local: true)` for local/scoped providers.
+const ease = Ease();

--- a/packages/ease_generator/lib/src/aggregator_builder.dart
+++ b/packages/ease_generator/lib/src/aggregator_builder.dart
@@ -96,7 +96,8 @@ class AggregatorBuilder implements Builder {
     buffer.writeln("/// import 'ease.g.dart';");
     buffer.writeln('///');
     buffer.writeln('/// void main() => runApp(');
-    buffer.writeln(r"///   Ease(providers: $easeProviders, child: MyApp()),");
+    buffer.writeln(
+        r"///   EaseScope(providers: $easeProviders, child: MyApp()),");
     buffer.writeln('/// );');
     buffer.writeln('/// ```');
     buffer.writeln(r'final $easeProviders = <ProviderBuilder>[');

--- a/packages/ease_generator/lib/src/generator.dart
+++ b/packages/ease_generator/lib/src/generator.dart
@@ -9,7 +9,7 @@ import 'utils.dart';
 ///
 /// Uses InheritedModel for optimal performance - supports selective rebuilds
 /// via aspects so only widgets that depend on specific state will rebuild.
-class EaseGenerator extends GeneratorForAnnotation<ease> {
+class EaseGenerator extends GeneratorForAnnotation<Ease> {
   @override
   String generateForAnnotatedElement(
     Element element,
@@ -155,7 +155,7 @@ extension ${className}Context on BuildContext {
       throw StateError(
         'No $className found in widget tree.\\n'
         'Make sure you:\\n'
-        '1. Wrapped your app with Ease widget: Ease(providers: [...], child: MyApp())\\n'
+        '1. Wrapped your app with EaseScope widget: EaseScope(providers: [...], child: MyApp())\\n'
         '2. Added ${className}Provider to your providers list',
       );
     }
@@ -168,7 +168,7 @@ extension ${className}Context on BuildContext {
       throw StateError(
         'No $className found in widget tree.\\n'
         'Make sure you:\\n'
-        '1. Wrapped your app with Ease widget: Ease(providers: [...], child: MyApp())\\n'
+        '1. Wrapped your app with EaseScope widget: EaseScope(providers: [...], child: MyApp())\\n'
         '2. Added ${className}Provider to your providers list',
       );
     }
@@ -184,7 +184,7 @@ extension ${className}Context on BuildContext {
       throw StateError(
         'No $className found in widget tree.\\n'
         'Make sure you:\\n'
-        '1. Wrapped your app with Ease widget: Ease(providers: [...], child: MyApp())\\n'
+        '1. Wrapped your app with EaseScope widget: EaseScope(providers: [...], child: MyApp())\\n'
         '2. Added ${className}Provider to your providers list',
       );
     }

--- a/packages/ease_generator/test/ease_generator_test.dart
+++ b/packages/ease_generator/test/ease_generator_test.dart
@@ -67,8 +67,10 @@ void main() {
         {
           'ease_annotation|lib/ease_annotation.dart': '''
 library ease_annotation;
-class ease {
-  const ease();
+class Ease {
+  const Ease();
+}
+const ease = Ease();
 }
 ''',
           'ease|lib/src/state_notifier.dart': '''
@@ -87,7 +89,7 @@ import 'package:ease/src/state_notifier.dart';
 
 part 'counter.ease.dart';
 
-@ease()
+@ease
 class CounterViewModel extends StateNotifier<int> {
   CounterViewModel() : super(0);
   void increment() => state++;
@@ -121,8 +123,10 @@ class CounterViewModel extends StateNotifier<int> {
         {
           'ease_annotation|lib/ease_annotation.dart': '''
 library ease_annotation;
-class ease {
-  const ease();
+class Ease {
+  const Ease();
+}
+const ease = Ease();
 }
 ''',
           'ease|lib/src/state_notifier.dart': '''
@@ -141,7 +145,7 @@ import 'package:ease/src/state_notifier.dart';
 
 part 'my_app_state.ease.dart';
 
-@ease()
+@ease
 class MyAppState extends StateNotifier<String> {
   MyAppState() : super('');
 }
@@ -168,8 +172,10 @@ class MyAppState extends StateNotifier<String> {
         {
           'ease_annotation|lib/ease_annotation.dart': '''
 library ease_annotation;
-class ease {
-  const ease();
+class Ease {
+  const Ease();
+}
+const ease = Ease();
 }
 ''',
           'ease|lib/src/state_notifier.dart': '''
@@ -188,7 +194,7 @@ import 'package:ease/src/state_notifier.dart';
 
 part 'cart.ease.dart';
 
-@ease()
+@ease
 class CartViewModel extends StateNotifier<List<String>> {
   CartViewModel() : super([]);
 }
@@ -215,8 +221,10 @@ class CartViewModel extends StateNotifier<List<String>> {
         {
           'ease_annotation|lib/ease_annotation.dart': '''
 library ease_annotation;
-class ease {
-  const ease();
+class Ease {
+  const Ease();
+}
+const ease = Ease();
 }
 ''',
           'ease|lib/src/state_notifier.dart': '''
@@ -235,7 +243,7 @@ import 'package:ease/src/state_notifier.dart';
 
 part 'auth.ease.dart';
 
-@ease()
+@ease
 class AuthViewModel extends StateNotifier<bool> {
   AuthViewModel() : super(false);
 }
@@ -246,7 +254,7 @@ class AuthViewModel extends StateNotifier<bool> {
           'a|lib/auth.ease.dart': decodedMatches(
             allOf([
               contains("'No AuthViewModel found in widget tree"),
-              contains('Wrapped your app with Ease widget'),
+              contains('Wrapped your app with EaseScope widget'),
             ]),
           ),
         },
@@ -261,8 +269,10 @@ class AuthViewModel extends StateNotifier<bool> {
         {
           'ease_annotation|lib/ease_annotation.dart': '''
 library ease_annotation;
-class ease {
-  const ease();
+class Ease {
+  const Ease();
+}
+const ease = Ease();
 }
 ''',
           'ease|lib/src/state_notifier.dart': '''
@@ -282,7 +292,7 @@ import 'package:ease/src/state_notifier.dart';
 
 part 'user.ease.dart';
 
-@ease()
+@ease
 class UserViewModel extends StateNotifier<Map<String, dynamic>> {
   UserViewModel() : super({});
 }
@@ -310,8 +320,10 @@ class UserViewModel extends StateNotifier<Map<String, dynamic>> {
         {
           'ease_annotation|lib/ease_annotation.dart': '''
 library ease_annotation;
-class ease {
-  const ease();
+class Ease {
+  const Ease();
+}
+const ease = Ease();
 }
 ''',
           'ease|lib/src/state_notifier.dart': '''
@@ -330,7 +342,7 @@ import 'package:ease/src/state_notifier.dart';
 
 part 'theme.ease.dart';
 
-@ease()
+@ease
 class ThemeViewModel extends StateNotifier<bool> {
   ThemeViewModel() : super(false);
 }
@@ -365,8 +377,10 @@ class ThemeViewModel extends StateNotifier<bool> {
         {
           'ease_annotation|lib/ease_annotation.dart': '''
 library ease_annotation;
-class ease {
-  const ease();
+class Ease {
+  const Ease();
+}
+const ease = Ease();
 }
 ''',
           'a|lib/invalid.dart': '''
@@ -374,7 +388,7 @@ import 'package:ease_annotation/ease_annotation.dart';
 
 part 'invalid.ease.dart';
 
-@ease()
+@ease
 class InvalidClass {
   final int value;
   InvalidClass(this.value);
@@ -415,8 +429,10 @@ class InvalidClass {
         {
           'ease_annotation|lib/ease_annotation.dart': '''
 library ease_annotation;
-class ease {
-  const ease();
+class Ease {
+  const Ease();
+}
+const ease = Ease();
 }
 ''',
           'ease|lib/src/state_notifier.dart': '''
@@ -439,7 +455,7 @@ class UserData {
   UserData(this.name, this.age);
 }
 
-@ease()
+@ease
 class UserState extends StateNotifier<UserData> {
   UserState() : super(UserData('', 0));
 }
@@ -465,8 +481,10 @@ class UserState extends StateNotifier<UserData> {
         {
           'ease_annotation|lib/ease_annotation.dart': '''
 library ease_annotation;
-class ease {
-  const ease();
+class Ease {
+  const Ease();
+}
+const ease = Ease();
 }
 ''',
           'ease|lib/src/state_notifier.dart': '''
@@ -483,7 +501,7 @@ import 'package:ease/src/state_notifier.dart';
 
 part 'cart.ease.dart';
 
-@ease()
+@ease
 class CartState extends StateNotifier<Map<String, List<int>>> {
   CartState() : super({});
 }

--- a/packages/ease_state_helper/lib/ease_state_helper.dart
+++ b/packages/ease_state_helper/lib/ease_state_helper.dart
@@ -12,8 +12,8 @@
 ///
 /// // 3. Run app
 /// void main() {
-///   initializeEase(); // Initialize DevTools (debug only)
-///   runApp(Ease(providers: [...], child: MyApp()));
+///   initializeEaseDevTool(); // Initialize DevTools (debug only)
+///   runApp(EaseScope(providers: [...], child: MyApp()));
 /// }
 ///
 /// // 4. Use
@@ -32,18 +32,18 @@ export 'src/middleware.dart';
 export 'src/middleware/logging_middleware.dart';
 export 'src/state_notifier.dart';
 
-/// Initialize Ease state management.
+/// Initialize Ease DevTools integration.
 ///
 /// Call this in your `main()` function before `runApp()` to enable
 /// DevTools integration in debug mode.
 ///
 /// ```dart
 /// void main() {
-///   initializeEase();
-///   runApp(Ease(providers: [...], child: MyApp()));
+///   initializeEaseDevTool();
+///   runApp(EaseScope(providers: [...], child: MyApp()));
 /// }
 /// ```
-void initializeEase() {
+void initializeEaseDevTool() {
   if (kDebugMode) {
     EaseDevTools().initialize();
   }

--- a/packages/ease_state_helper/lib/src/devtools.dart
+++ b/packages/ease_state_helper/lib/src/devtools.dart
@@ -18,8 +18,8 @@ import 'state_notifier.dart';
 /// Usage:
 /// ```dart
 /// void main() {
-///   initializeEase(); // Initialize DevTools (debug only)
-///   runApp(const Ease(child: MyApp()));
+///   initializeEaseDevTool(); // Initialize DevTools (debug only)
+///   runApp(const EaseScope(child: MyApp()));
 /// }
 /// ```
 class EaseDevTools {

--- a/packages/ease_state_helper/lib/src/ease_widget.dart
+++ b/packages/ease_state_helper/lib/src/ease_widget.dart
@@ -16,7 +16,7 @@ typedef ProviderBuilder = Widget Function(Widget child);
 ///
 /// ```dart
 /// // Generated ease.g.dart provides providers automatically
-/// void main() => runApp(Ease(child: MyApp()));
+/// void main() => runApp(EaseScope(child: MyApp()));
 /// ```
 ///
 /// ## Without Code Generation (manual registration)
@@ -25,7 +25,7 @@ typedef ProviderBuilder = Widget Function(Widget child);
 ///
 /// ```dart
 /// void main() => runApp(
-///   Ease(
+///   EaseScope(
 ///     providers: [
 ///       (child) => CartViewModelProvider(child: child),
 ///       (child) => AuthViewModelProvider(child: child),
@@ -39,7 +39,7 @@ typedef ProviderBuilder = Widget Function(Widget child);
 ///
 /// Note: Local providers (`@ease(local: true)`) are not included here.
 /// They must be manually placed in your widget tree.
-class Ease extends StatelessWidget {
+class EaseScope extends StatelessWidget {
   /// The child widget to wrap with all providers.
   final Widget child;
 
@@ -49,12 +49,12 @@ class Ease extends StatelessWidget {
   /// For manual registration, pass your providers here.
   final List<ProviderBuilder> providers;
 
-  /// Creates an Ease root widget.
+  /// Creates an EaseScope root widget.
   ///
   /// [providers] - List of provider builder functions. Empty by default
   /// for code-generated usage where providers are added to `_providers`.
   /// [child] - The widget tree to wrap with providers.
-  const Ease({
+  const EaseScope({
     super.key,
     required this.child,
     this.providers = const [],

--- a/packages/ease_state_helper/test/ease_widget_test.dart
+++ b/packages/ease_state_helper/test/ease_widget_test.dart
@@ -6,7 +6,7 @@ void main() {
   group('Ease widget', () {
     testWidgets('renders child when no providers', (tester) async {
       await tester.pumpWidget(
-        const Ease(
+        const EaseScope(
           child: Text('Hello', textDirection: TextDirection.ltr),
         ),
       );
@@ -18,7 +18,7 @@ void main() {
       var providerCalled = false;
 
       await tester.pumpWidget(
-        Ease(
+        EaseScope(
           providers: [
             (child) {
               providerCalled = true;
@@ -37,7 +37,7 @@ void main() {
       final order = <int>[];
 
       await tester.pumpWidget(
-        Ease(
+        EaseScope(
           providers: [
             (child) {
               order.add(1);
@@ -69,7 +69,7 @@ void main() {
       // With fold, providers are applied in order: p1(p2(p3(child)))
       // So the last provider in the list becomes the outermost wrapper
       await tester.pumpWidget(
-        Ease(
+        EaseScope(
           providers: [
             (child) => Container(key: const Key('first'), child: child),
             (child) => Container(key: const Key('last'), child: child),


### PR DESCRIPTION
## Summary

- Add pana scoring checks to CI workflow
- Rename `Ease` widget → `EaseScope` to avoid naming conflict with annotation
- Rename `class ease` → `class Ease` with `const ease = Ease()` pattern
- Rename `initializeEase()` → `initializeEaseDevTool()`
- Update VS Code extension templates

## Breaking Changes

- `Ease` widget renamed to `EaseScope`
- `initializeEase()` renamed to `initializeEaseDevTool()`
- Annotation usage: `@ease` (simple) or `@Ease(local: true)` (with params)

Closes #3